### PR TITLE
Add setup guide with architecture diagram

### DIFF
--- a/docs/images/docker-architecture.svg
+++ b/docs/images/docker-architecture.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="300">
+  <rect x="10" y="10" width="480" height="280" fill="#e0f7fa" stroke="#006064" stroke-width="2" />
+  <text x="250" y="30" font-size="18" text-anchor="middle" fill="#006064">Docker Compose</text>
+  <rect x="40" y="60" width="120" height="60" fill="#e0e0e0" stroke="#424242" stroke-width="1" />
+  <text x="100" y="95" font-size="14" text-anchor="middle" fill="#000">Frontend</text>
+  <rect x="190" y="60" width="120" height="60" fill="#e0e0e0" stroke="#424242" stroke-width="1" />
+  <text x="250" y="95" font-size="14" text-anchor="middle" fill="#000">Backend</text>
+  <rect x="340" y="60" width="120" height="60" fill="#e0e0e0" stroke="#424242" stroke-width="1" />
+  <text x="400" y="95" font-size="14" text-anchor="middle" fill="#000">AI Service</text>
+</svg>

--- a/docs/setup-directions.md
+++ b/docs/setup-directions.md
@@ -1,0 +1,26 @@
+# Setup Guide
+
+This guide explains how to launch the container stack for this project.
+
+1. Duplicate the sample environment configuration:
+
+```bash
+cp .env.example .env
+```
+
+2. Allow helper scripts to execute:
+
+```bash
+./make-executable.sh
+```
+
+3. Start the services. Choose `dev` or `prod` as needed:
+
+```bash
+./docker-start.sh dev
+```
+
+Below is a simple overview of the container layout.
+
+![Docker architecture](images/docker-architecture.svg)
+


### PR DESCRIPTION
## Summary
- document how to run the container stack
- include a small architecture diagram

## Testing
- `git status --short`