### PR TITLE
Improve logging and import checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ cp .env.example .env
 ./docker-start.sh dev   # or 'prod'
 ```
 
+Logs for the AI service are written to the path specified by `LOG_FILE`
+(default `./logs/app.log`).
+
 The containers will start, but the application services are empty until the
 source code is added.
 

--- a/src/ai/main.py
+++ b/src/ai/main.py
@@ -1,25 +1,56 @@
 import os
+import logging
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-import openai
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - graceful handling if package is missing
+    openai = None
+
+
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+log_file = os.getenv("LOG_FILE")
+
+logging.basicConfig(
+    level=getattr(logging, log_level, logging.INFO),
+    filename=log_file,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
     CORS(app)
 
-    openai.api_key = os.getenv("OPENAI_API_KEY")
     model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    if openai is not None:
+        openai.api_key = openai_api_key
+    if not openai_api_key:
+        logger.warning("OPENAI_API_KEY environment variable is not set")
 
     @app.route("/health", methods=["GET"])
     def health() -> jsonify:
+        logger.debug("/health check")
         return jsonify(status="ok")
 
     @app.route("/analyze", methods=["POST"])
     def analyze():
+        logger.info("/analyze request received")
+        if openai is None:
+            logger.error("OpenAI package is not installed")
+            return jsonify(error="OpenAI package not installed"), 500
+
+        if not openai.api_key:
+            logger.error("OPENAI_API_KEY is not configured")
+            return jsonify(error="OPENAI_API_KEY not set"), 500
+
         data = request.get_json() or {}
         script = data.get("script")
         if not script:
+            logger.warning("Missing 'script' in request body")
             return jsonify(error="Missing 'script' in request"), 400
 
         prompt = (
@@ -39,13 +70,17 @@ def create_app() -> Flask:
                 temperature=0.2,
             )
             analysis = response.choices[0].message["content"].strip()
+            logger.info("Analysis completed successfully")
             return jsonify(analysis=analysis)
         except Exception as exc:
+            logger.exception("Error during analysis")
             return jsonify(error=str(exc)), 500
 
+    logger.info("Flask application created")
     return app
 
 
 if __name__ == "__main__":
     app = create_app()
+    logger.info("Starting Flask server")
     app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- configure `main.py` logger from environment variables
- gracefully handle missing `openai` package
- add request/response logs and warn when API key is unset
- mention log file location in README

## Testing
- `python -m py_compile src/ai/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6854db4f14bc832eac9dbdb9e489e91f