### PR TITLE
Add update script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The remaining application services are still under development.
 - `docker-compose.override.yml` – development overrides
 - `docker-start.sh` – helper script to launch containers
 - `make-executable.sh` – sets execute permissions for scripts
+- `update-app.sh` – pulls the latest code and rebuilds containers
 - `src/ai` – placeholder for the Python AI service
 - `src/backend` – placeholder for the Node.js API
 - `src/frontend` – placeholder for the React frontend
@@ -33,7 +34,7 @@ The remaining application services are still under development.
 cp .env.example .env
 ```
 
-2. Make the startup script executable and run the containers:
+2. Make the helper scripts executable and run the containers:
 
 ```bash
 ./make-executable.sh
@@ -45,6 +46,14 @@ Logs for the AI service are written to the path specified by `LOG_FILE`
 
 The containers will start, but the application services are empty until the
 source code is added.
+
+## Updating
+
+To fetch the latest code and rebuild the containers, run:
+
+```bash
+./update-app.sh dev   # or 'prod'
+```
 
 ## Contributing
 

--- a/docs/setup-directions.md
+++ b/docs/setup-directions.md
@@ -20,6 +20,12 @@ cp .env.example .env
 ./docker-start.sh dev
 ```
 
+4. When updates are available, fetch the latest code and rebuild:
+
+```bash
+./update-app.sh dev
+```
+
 Below is a simple overview of the container layout.
 
 ![Docker architecture](images/docker-architecture.svg)

--- a/make-executable.sh
+++ b/make-executable.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Make scripts executable
-chmod +x docker-start.sh
+chmod +x docker-start.sh update-app.sh
 
 echo "Scripts are now executable."

--- a/update-app.sh
+++ b/update-app.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Update PSScript Manager and restart containers
+# Usage: ./update-app.sh [dev|prod]
+
+ENV=${1:-"prod"}
+
+echo "========================================"
+echo "Updating PSScript Manager in $ENV mode"
+echo "========================================"
+
+# Ensure we are inside the repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+# Pull latest code
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  git pull --ff-only
+else
+  echo "This script must be run from inside the git repository" >&2
+  exit 1
+fi
+
+# Pull latest container images and rebuild
+if [ "$ENV" = "dev" ]; then
+  docker-compose -f docker-compose.yml -f docker-compose.override.yml pull
+  docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build -d
+else
+  docker-compose pull
+  docker-compose up --build -d
+fi
+
+echo "Update complete."


### PR DESCRIPTION
## Summary
- add `update-app.sh` script for easy updates
- make helper scripts executable including update script
- document update script in README and setup guide

## Testing
- `bash -n update-app.sh`
- `bash -n make-executable.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854de777dd0832ea721df10147dc1fb