### PR TITLE
Add cloning step to setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ The remaining application services are still under development.
 - `src/backend` – placeholder for the Node.js API
 - `src/frontend` – placeholder for the React frontend
 
+## Installation
+
+First, clone the repository to your local machine:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/psscript-manager.git
+cd psscript-manager
+```
+
+The root of the cloned project contains a `.env.example` file that you'll copy in the next step.
+
 ## Getting Started
 
 1. Copy the example environment file:
@@ -44,8 +55,7 @@ cp .env.example .env
 Logs for the AI service are written to the path specified by `LOG_FILE`
 (default `./logs/app.log`).
 
-The containers will start, but the application services are empty until the
-source code is added.
+The containers will start, but the application services are empty until the source code is added.
 
 ## Updating
 

--- a/docs/setup-directions.md
+++ b/docs/setup-directions.md
@@ -2,6 +2,15 @@
 
 This guide explains how to launch the container stack for this project.
 
+First, obtain the source code locally:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/psscript-manager.git
+cd psscript-manager
+```
+
+After cloning, continue with the steps below.
+
 1. Duplicate the sample environment configuration:
 
 ```bash


### PR DESCRIPTION
## Summary
- add install section to README
- clarify cloning instructions in setup guide

## Testing
- `python3 -m py_compile src/ai/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6854e041cc44832eba02f6494325b14d