### PR TITLE
Add simple dashboard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It bundles a collection of Docker services to help you explore, categorize and s
 - Multi‑agent system (planned)
 - Documentation integration
 - User authentication
+- Built-in dashboard for analyzing scripts
 
 ## Architecture
 
@@ -39,7 +40,8 @@ A simplified view of the container layout.
    ./setup-check.sh dev
    ```
    The script checks prerequisites, creates a `.env` file if needed and launches the containers.
-3. Access the frontend at `http://localhost:5173` once the stack is running.
+3. Access the dashboard at `http://localhost:5000/dashboard` once the stack is running.
+   The placeholder React frontend is still available at `http://localhost:5173`.
 
 Logs for the AI service are written to the path specified by `LOG_FILE` in your `.env` file (default `./logs/app.log`).
 

--- a/src/ai/main.py
+++ b/src/ai/main.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from pathlib import Path
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 
@@ -75,6 +76,15 @@ def create_app() -> Flask:
         except Exception as exc:
             logger.exception("Error during analysis")
             return jsonify(error=str(exc)), 500
+
+    static_dir = Path(__file__).parent / "static"
+
+    @app.route("/dashboard", methods=["GET"])
+    def dashboard():
+        html_path = static_dir / "dashboard.html"
+        if html_path.exists():
+            return html_path.read_text(), 200, {"Content-Type": "text/html"}
+        return "<p>Dashboard not found</p>", 404, {"Content-Type": "text/html"}
 
     logger.info("Flask application created")
     return app

--- a/src/ai/static/dashboard.html
+++ b/src/ai/static/dashboard.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PSScript Manager Dashboard</title>
+</head>
+<body>
+<h1>PSScript Manager Dashboard</h1>
+<form id="analyze-form">
+    <textarea id="script" rows="10" cols="70" placeholder="Paste PowerShell script here"></textarea><br>
+    <button type="submit">Analyze</button>
+</form>
+<pre id="result"></pre>
+<script>
+document.getElementById('analyze-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const script = document.getElementById('script').value;
+    const res = await fetch('/analyze', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({script})
+    });
+    const data = await res.json();
+    document.getElementById('result').textContent = data.analysis || data.error;
+});
+</script>
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,6 +47,7 @@ def test_create_app_and_routes():
     assert isinstance(app, Flask)
     assert ('/health', ('GET',)) in app.routes
     assert ('/analyze', ('POST',)) in app.routes
+    assert ('/dashboard', ('GET',)) in app.routes
 
 
 def test_analyze_without_openai(tmp_path):


### PR DESCRIPTION
## Summary
- expose a `/dashboard` route in the AI service to serve a small HTML page
- test the new route
- document the dashboard usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f3fb9dcc832ea5eafd8db52256ea