### PR TITLE
Add basic stats tracking for analyses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A simplified view of the container layout.
    The script checks prerequisites, creates a `.env` file if needed and launches the containers.
 3. Access the dashboard at `http://localhost:5000/dashboard` once the stack is running.
    The placeholder React frontend is still available at `http://localhost:5173`.
+   A basic statistics endpoint is available at `http://localhost:5000/stats`.
 
 Logs for the AI service are written to the path specified by `LOG_FILE` in your `.env` file (default `./logs/app.log`).
 

--- a/src/ai/static/dashboard.html
+++ b/src/ai/static/dashboard.html
@@ -6,12 +6,21 @@
 </head>
 <body>
 <h1>PSScript Manager Dashboard</h1>
+<div id="stats">Analyses performed: <span id="analysis-count">0</span></div>
 <form id="analyze-form">
     <textarea id="script" rows="10" cols="70" placeholder="Paste PowerShell script here"></textarea><br>
     <button type="submit">Analyze</button>
 </form>
 <pre id="result"></pre>
 <script>
+async function updateStats() {
+    const res = await fetch('/stats');
+    if (res.ok) {
+        const data = await res.json();
+        document.getElementById('analysis-count').textContent = data.analysis_count;
+    }
+}
+
 document.getElementById('analyze-form').addEventListener('submit', async (e) => {
     e.preventDefault();
     const script = document.getElementById('script').value;
@@ -22,7 +31,10 @@ document.getElementById('analyze-form').addEventListener('submit', async (e) => 
     });
     const data = await res.json();
     document.getElementById('result').textContent = data.analysis || data.error;
+    updateStats();
 });
+
+document.addEventListener('DOMContentLoaded', updateStats);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track number of analyses performed in the AI service
- expose `/stats` endpoint and display count on dashboard
- update dashboard HTML with stats section and JS logic
- document stats endpoint in README
- add tests for stats endpoint and tracking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554dbe167c832e80d0fea10a5c074b