### PR TITLE
Improve AI analysis output

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ A simplified view of the container layout.
 
 Logs for the AI service are written to the path specified by `LOG_FILE` in your `.env` file (default `./logs/app.log`).
 
+You can also send requests directly to the AI `/analyze` endpoint:
+
+```bash
+curl -X POST http://localhost:5000/analyze \
+     -H "Content-Type: application/json" \
+     -d '{"script": "Get-Process"}'
+```
+
+The response includes a summary, key cmdlets with definitions and examples, and links to related Microsoft Learn articles when available.
+
 ## Project Structure
 - `docker-compose.yml` & `docker-compose.override.yml` – container configuration
 - `docker-start.sh` – manual script to start containers

--- a/src/ai/main.py
+++ b/src/ai/main.py
@@ -55,8 +55,10 @@ def create_app() -> Flask:
             return jsonify(error="Missing 'script' in request"), 400
 
         prompt = (
-            "Analyze the following PowerShell script and summarize its purpose. "
-            "Also identify any potential issues:\n\n" + script
+            "Analyze the following PowerShell script. Summarize its purpose, "
+            "list the key cmdlets with a short definition and example usage, "
+            "and include the Microsoft Learn URL for each when possible. "
+            "Identify any potential issues:\n\n" + script
         )
         try:
             response = openai.ChatCompletion.create(


### PR DESCRIPTION
## Summary
- extend `/analyze` endpoint prompt with key cmdlets, examples, and links to Microsoft Learn
- document API usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554e2e7cac832eb0eb84a02ceb148d