### PR TITLE
Fix GitHub links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ We welcome feature suggestions! Please create an issue with:
 
 1. Clone your fork of the repository
    ```bash
-   git clone https://github.com/YOUR_USERNAME/psscript-manager.git
+   git clone https://github.com/Morlock52/psscript-manager.git
    cd psscript-manager
    ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PSScript Manager
 
-![License](https://img.shields.io/github/license/YOUR_USERNAME/psscript-manager?style=flat-square)
+![License](https://img.shields.io/github/license/Morlock52/psscript-manager?style=flat-square)
 
 PSScript Manager is an **AI-powered** platform for managing and analyzing PowerShell scripts.
 It bundles a collection of Docker services to help you explore, categorize and search scripts with the help of language models.
@@ -32,7 +32,7 @@ A simplified view of the container layout.
 ## Quick Start
 1. Clone the repository:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/psscript-manager.git
+   git clone https://github.com/Morlock52/psscript-manager.git
    cd psscript-manager
    ```
 2. Run the helper script (choose `dev` or `prod`):

--- a/docs/setup-directions.md
+++ b/docs/setup-directions.md
@@ -7,7 +7,7 @@ possible, checks port availability, and then starts the stack.
 ## 1. Clone the repository
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/psscript-manager.git
+git clone https://github.com/Morlock52/psscript-manager.git
 cd psscript-manager
 ```
 


### PR DESCRIPTION
## Summary
- replace placeholder repository links with correct `Morlock52` path in README, contributing guide and setup docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856046b66c0832e86d7df9793ef0764