### PR TITLE
Add OpenAI configuration management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ AI_SERVICE_API_KEY=your_ai_service_api_key_here
 # OpenAI (for AI service)
 OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_MODEL=gpt-4-turbo
+# Update these with `python scripts/openai_config.py`
 
 # Vector Database
 PGVECTOR_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ curl -X POST http://localhost:5000/analyze \
 
 The response includes a summary, key cmdlets with definitions and examples, and links to related Microsoft Learn articles when available.
 
+### Configuring OpenAI
+
+Use the `scripts/openai_config.py` helper to set your OpenAI API key and choose the model. The script updates your `.env` file:
+
+```bash
+python scripts/openai_config.py
+```
+
+The tool will prompt for your API key, query available models and let you select one to store in `.env` as `OPENAI_MODEL`.
+
 ## Project Structure
 - `docker-compose.yml` & `docker-compose.override.yml` – container configuration
 - `docker-start.sh` – manual script to start containers

--- a/scripts/openai_config.py
+++ b/scripts/openai_config.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Utility to update OpenAI API settings in the .env file."""
+import os
+import sys
+from pathlib import Path
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+ENV_FILE = Path('.env')
+
+
+def update_env(key: str, value: str) -> None:
+    lines = []
+    if ENV_FILE.exists():
+        lines = ENV_FILE.read_text().splitlines()
+    mapping = {line.split('=', 1)[0]: i for i, line in enumerate(lines) if '=' in line}
+    new_line = f"{key}={value}"
+    if key in mapping:
+        lines[mapping[key]] = new_line
+    else:
+        lines.append(new_line)
+    ENV_FILE.write_text("\n".join(lines) + "\n")
+
+
+def list_models(api_key: str):
+    if openai is None:
+        print("openai package is not installed", file=sys.stderr)
+        return []
+    openai.api_key = api_key
+    try:
+        resp = openai.Model.list()
+        return [m['id'] for m in resp.get('data', [])]
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        print(f"Error fetching models: {exc}", file=sys.stderr)
+        return []
+
+
+def main() -> None:
+    api_key = input("Enter OpenAI API key: ").strip()
+    if not api_key:
+        print("API key is required")
+        return
+    update_env('OPENAI_API_KEY', api_key)
+    models = list_models(api_key)
+    if not models:
+        print("No models retrieved.")
+        return
+    print("Available models:")
+    for i, m in enumerate(models, 1):
+        print(f"{i}. {m}")
+    choice = input("Select model number: ").strip()
+    try:
+        idx = int(choice) - 1
+        model = models[idx]
+    except Exception:
+        print("Invalid selection")
+        return
+    update_env('OPENAI_MODEL', model)
+    print(f"Saved OPENAI_MODEL={model} in {ENV_FILE}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/ai/static/dashboard.html
+++ b/src/ai/static/dashboard.html
@@ -11,6 +11,12 @@
     <textarea id="script" rows="10" cols="70" placeholder="Paste PowerShell script here"></textarea><br>
     <button type="submit">Analyze</button>
 </form>
+<h2>OpenAI Settings</h2>
+<form id="settings-form">
+    <input type="text" id="api-key" placeholder="OpenAI API Key"><br>
+    <select id="model"></select>
+    <button type="submit">Save Settings</button>
+</form>
 <pre id="result"></pre>
 <script>
 async function updateStats() {
@@ -34,7 +40,38 @@ document.getElementById('analyze-form').addEventListener('submit', async (e) => 
     updateStats();
 });
 
-document.addEventListener('DOMContentLoaded', updateStats);
+async function loadModels() {
+    const res = await fetch('/models');
+    if (res.ok) {
+        const data = await res.json();
+        const select = document.getElementById('model');
+        select.innerHTML = '';
+        data.models.forEach(m => {
+            const opt = document.createElement('option');
+            opt.value = m;
+            opt.textContent = m;
+            select.appendChild(opt);
+        });
+    }
+}
+
+document.getElementById('settings-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const api_key = document.getElementById('api-key').value;
+    const model = document.getElementById('model').value;
+    const res = await fetch('/config', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ api_key, model })
+    });
+    const data = await res.json();
+    alert(data.status ? 'Settings updated' : data.error);
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    updateStats();
+    loadModels();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow dashboard to update API key and model
- expose `/models` and `/config` endpoints in AI service
- persist configuration changes to `.env`
- add helper `scripts/openai_config.py`
- document new script in README
- update sample `.env`
- test the new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685604a74654832eb0d1d584b73ebc5e