### PR TITLE
Add dashboard OpenAI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ python scripts/openai_config.py
 
 The tool will prompt for your API key, query available models and let you select one to store in `.env` as `OPENAI_MODEL`.
 
+You can also manage these settings directly from the dashboard using the `/config` endpoint.
+`GET /config` returns the saved model and whether an API key is configured,
+while `POST /config` updates the values and persists them to `.env`.
+
 ## Project Structure
 - `docker-compose.yml` & `docker-compose.override.yml` – container configuration
 - `docker-start.sh` – manual script to start containers

--- a/src/ai/main.py
+++ b/src/ai/main.py
@@ -121,6 +121,14 @@ def create_app() -> Flask:
             logger.exception("Error fetching models")
             return jsonify(error=str(exc)), 500
 
+    @app.route("/config", methods=["GET"])
+    def get_config():
+        """Return current model and whether the API key is configured."""
+        return (
+            jsonify(model=model, api_key_configured=bool(openai and openai.api_key)),
+            200,
+        )
+
     @app.route("/config", methods=["POST"])
     def update_config():
         """Update API key and model configuration."""
@@ -140,7 +148,10 @@ def create_app() -> Flask:
             updates["OPENAI_MODEL"] = new_model
         if updates:
             _update_env_file(updates)
-        return jsonify(status="ok", model=model), 200
+        return (
+            jsonify(status="ok", model=model, api_key_configured=bool(openai and openai.api_key)),
+            200,
+        )
 
     static_dir = Path(__file__).parent / "static"
 

--- a/src/ai/static/dashboard.html
+++ b/src/ai/static/dashboard.html
@@ -40,7 +40,7 @@ document.getElementById('analyze-form').addEventListener('submit', async (e) => 
     updateStats();
 });
 
-async function loadModels() {
+async function loadModels(selected) {
     const res = await fetch('/models');
     if (res.ok) {
         const data = await res.json();
@@ -50,8 +50,18 @@ async function loadModels() {
             const opt = document.createElement('option');
             opt.value = m;
             opt.textContent = m;
+            if (m === selected) opt.selected = true;
             select.appendChild(opt);
         });
+    }
+}
+
+async function fetchConfig() {
+    const res = await fetch('/config');
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data.api_key_configured) {
+        await loadModels(data.model);
     }
 }
 
@@ -65,12 +75,17 @@ document.getElementById('settings-form').addEventListener('submit', async (e) =>
         body: JSON.stringify({ api_key, model })
     });
     const data = await res.json();
-    alert(data.status ? 'Settings updated' : data.error);
+    if (data.status) {
+        await fetchConfig();
+        alert('Settings updated');
+    } else {
+        alert(data.error);
+    }
 });
 
 document.addEventListener('DOMContentLoaded', () => {
     updateStats();
-    loadModels();
+    fetchConfig();
 });
 </script>
 </body>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -138,3 +138,22 @@ def test_update_config_persists_env(tmp_path):
     assert status == 200
     assert main.openai.api_key == 'new'
     assert 'OPENAI_MODEL=gpt-4' in env_file.read_text()
+
+
+def test_get_config_returns_state(tmp_path):
+    class FakeOpenAI:
+        api_key = 'abc'
+        Model = type('M', (), {})
+        ChatCompletion = type('Chat', (), {})
+
+    os.environ['OPENAI_API_KEY'] = 'abc'
+    os.environ['OPENAI_MODEL'] = 'gpt-test'
+    logging.getLogger().handlers.clear()
+    importlib.reload(main)
+    main.openai = FakeOpenAI
+    app = main.create_app()
+    get_config = app.routes[('/config', ('GET',))]
+    result, status = get_config()
+    assert status == 200
+    assert result['model'] == 'gpt-test'
+    assert result['api_key_configured'] is True


### PR DESCRIPTION
## Summary
- expose new `/config` GET endpoint and include API key status in POST response
- update dashboard to fetch configuration and reload models when settings change
- mention `/config` endpoint in README
- test new `/config` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560c417888832e95a588c8d6f69f32