### PR TITLE
Align backend AI client with FastAPI AI service contract

### DIFF
--- a/docs/AI_SERVICE_API_CONTRACT.md
+++ b/docs/AI_SERVICE_API_CONTRACT.md
@@ -1,0 +1,151 @@
+# AI Service API Contract
+
+This document defines the API contract between the backend and the FastAPI AI service in `src/ai/main.py`.
+
+## Base URL
+
+```
+http://<ai-service-host>:8000
+```
+
+## Authentication
+
+Send the AI provider key with requests as the header below when running in production:
+
+```
+X-API-KEY: <openai_api_key>
+```
+
+## Endpoints
+
+### POST `/analyze`
+
+Analyze a PowerShell script and return structured analysis.
+
+**Query Parameters**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `include_command_details` | boolean | `false` | Include per-command details. |
+| `fetch_ms_docs` | boolean | `false` | Fetch Microsoft Docs references. |
+
+**Request Body**
+
+```json
+{
+  "content": "string",
+  "script_id": 123,
+  "script_name": "optional-name.ps1"
+}
+```
+
+**Response**
+
+```json
+{
+  "purpose": "string",
+  "security_analysis": "string",
+  "security_score": 5,
+  "code_quality_score": 5,
+  "parameters": {},
+  "category": "Utilities & Helpers",
+  "category_id": 10,
+  "command_details": [],
+  "ms_docs_references": [],
+  "optimization": [],
+  "risk_score": 5
+}
+```
+
+### POST `/chat`
+
+Chat with the PowerShell expert assistant.
+
+**Request Body**
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "string" }
+  ],
+  "system_prompt": "optional system prompt",
+  "agent_type": "assistant",
+  "session_id": "optional-session"
+}
+```
+
+**Response**
+
+```json
+{
+  "response": "string",
+  "session_id": "optional-session"
+}
+```
+
+### POST `/embedding`
+
+Create an embedding for script content.
+
+**Request Body**
+
+```json
+{
+  "content": "string"
+}
+```
+
+**Response**
+
+```json
+{
+  "embedding": [0.01, 0.02]
+}
+```
+
+### POST `/similar`
+
+Find similar scripts based on content or stored script ID.
+
+**Request Body**
+
+```json
+{
+  "script_id": 123,
+  "content": "optional-content",
+  "limit": 5
+}
+```
+
+**Response**
+
+```json
+{
+  "similar_scripts": [
+    {
+      "script_id": 456,
+      "title": "string",
+      "similarity": 0.85
+    }
+  ]
+}
+```
+
+### GET `/health`
+
+Health check for the AI service.
+
+**Response**
+
+```json
+{
+  "status": "healthy",
+  "timestamp": 1710000000,
+  "checks": {
+    "api_key": true,
+    "database": true,
+    "agent_coordinator": "enabled",
+    "mode": "production"
+  }
+}
+```

--- a/scripts/test-ai-service-contract.sh
+++ b/scripts/test-ai-service-contract.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AI_SERVICE_URL="${AI_SERVICE_URL:-http://localhost:8000}"
+API_KEY_HEADER=()
+
+if [[ -n "${AI_SERVICE_API_KEY:-}" ]]; then
+  API_KEY_HEADER=(-H "x-api-key: ${AI_SERVICE_API_KEY}")
+fi
+
+failures=0
+
+function check() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "PASS: ${name}"
+  else
+    echo "FAIL: ${name}"
+    failures=$((failures + 1))
+  fi
+}
+
+function expect_status() {
+  local expected="$1"
+  shift
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" "$@")
+  [[ "$status" == "$expected" ]]
+}
+
+function expect_json_field() {
+  local jq_filter="$1"
+  shift
+  local output
+  output=$(curl -s "$@")
+  echo "$output" | jq -e "$jq_filter" > /dev/null
+}
+
+check "health endpoint" \
+  expect_status 200 "${AI_SERVICE_URL}/health"
+
+check "chat endpoint" \
+  expect_json_field '.response' \
+  -H "Content-Type: application/json" \
+  "${API_KEY_HEADER[@]}" \
+  -d '{"messages":[{"role":"user","content":"Say hello"}]}' \
+  "${AI_SERVICE_URL}/chat"
+
+check "analyze endpoint" \
+  expect_json_field '.purpose' \
+  -H "Content-Type: application/json" \
+  "${API_KEY_HEADER[@]}" \
+  -d '{"content":"Write-Output \"Hello\"","script_name":"hello.ps1"}' \
+  "${AI_SERVICE_URL}/analyze"
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "${failures} checks failed."
+  exit 1
+fi
+

--- a/src/backend/src/utils/aiService.ts
+++ b/src/backend/src/utils/aiService.ts
@@ -15,23 +15,50 @@ const AI_SERVICE_URL = isDocker
  * AI Service client for handling all AI-related operations
  */
 class AiServiceClient {
+  private getApiHeaders() {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json'
+    };
+
+    if (process.env.AI_SERVICE_API_KEY) {
+      headers['x-api-key'] = process.env.AI_SERVICE_API_KEY;
+    }
+
+    return headers;
+  }
+
+  private async postChat(messages: Array<{ role: string; content: string }>, options?: {
+    systemPrompt?: string;
+    agentType?: string;
+    sessionId?: string;
+  }) {
+    const response = await axios.post(`${AI_SERVICE_URL}/chat`, {
+      messages,
+      system_prompt: options?.systemPrompt,
+      agent_type: options?.agentType,
+      session_id: options?.sessionId
+    }, {
+      timeout: 60000,
+      headers: this.getApiHeaders()
+    });
+
+    return response.data;
+  }
+
   /**
    * Ask a question to the AI assistant
    */
   async askQuestion(question: string, context?: string, useAgent: boolean = true) {
     try {
-      const response = await axios.post(`${AI_SERVICE_URL}/api/ask`, {
-        question,
-        context,
-        useAgent
-      }, {
-        timeout: 60000, // 60 seconds timeout
-        headers: {
-          'Content-Type': 'application/json'
-        }
+      const content = context
+        ? `Context:\n${context}\n\nQuestion:\n${question}`
+        : question;
+
+      return await this.postChat([
+        { role: 'user', content }
+      ], {
+        agentType: useAgent ? 'assistant' : undefined
       });
-      
-      return response.data;
     } catch (error) {
       logger.error('Error calling AI service for question:', error);
       throw new Error('AI service is unavailable. Please ensure the AI service is running and configured with a valid API key.');
@@ -43,16 +70,15 @@ class AiServiceClient {
    */
   async generateScript(description: string) {
     try {
-      const response = await axios.post(`${AI_SERVICE_URL}/api/generate`, {
-        description
-      }, {
-        timeout: 60000,
-        headers: {
-          'Content-Type': 'application/json'
-        }
+      const systemPrompt = 'Generate a PowerShell script that matches the user description. ' 
+        + 'Return only the script content without additional commentary.';
+
+      return await this.postChat([
+        { role: 'user', content: description }
+      ], {
+        systemPrompt,
+        agentType: 'assistant'
       });
-      
-      return response.data;
     } catch (error) {
       logger.error('Error calling AI service for script generation:', error);
       throw new Error('AI service is unavailable. Please ensure the AI service is running and configured with a valid API key.');
@@ -64,18 +90,22 @@ class AiServiceClient {
    */
   async analyzeScript(content: string, filename?: string, requestType: string = 'standard', analysisOptions?: any) {
     try {
-      const response = await axios.post(`${AI_SERVICE_URL}/api/analyze`, {
+      const includeCommandDetails = analysisOptions?.includeCommandDetails
+        ?? requestType === 'detailed';
+      const fetchMsDocs = analysisOptions?.includeInternetSearch ?? false;
+
+      const response = await axios.post(`${AI_SERVICE_URL}/analyze`, {
         content,
-        filename,
-        requestType,
-        analysisOptions
+        script_name: filename
       }, {
         timeout: 60000,
-        headers: {
-          'Content-Type': 'application/json'
+        headers: this.getApiHeaders(),
+        params: {
+          include_command_details: includeCommandDetails,
+          fetch_ms_docs: fetchMsDocs
         }
       });
-      
+
       return response.data;
     } catch (error) {
       logger.error('Error calling AI service for script analysis:', error);
@@ -88,17 +118,15 @@ class AiServiceClient {
    */
   async explainScript(content: string, type: string = 'simple') {
     try {
-      const response = await axios.post(`${AI_SERVICE_URL}/api/explain`, {
-        content,
-        type
-      }, {
-        timeout: 60000,
-        headers: {
-          'Content-Type': 'application/json'
-        }
+      const systemPrompt = type === 'detailed'
+        ? 'Explain the following PowerShell script in detail, including key commands and behavior.'
+        : 'Explain the following PowerShell script in simple terms.';
+
+      return await this.postChat([
+        { role: 'user', content }
+      ], {
+        systemPrompt
       });
-      
-      return response.data;
     } catch (error) {
       logger.error('Error calling AI service for explanation:', error);
       throw new Error('AI service is unavailable. Please ensure the AI service is running and configured with a valid API key.');
@@ -110,16 +138,14 @@ class AiServiceClient {
    */
   async getSimilarExamples(description: string, limit: number = 5) {
     try {
-      const response = await axios.post(`${AI_SERVICE_URL}/api/examples`, {
-        description,
+      const response = await axios.post(`${AI_SERVICE_URL}/similar`, {
+        content: description,
         limit
       }, {
         timeout: 60000,
-        headers: {
-          'Content-Type': 'application/json'
-        }
+        headers: this.getApiHeaders()
       });
-      
+
       return response.data;
     } catch (error) {
       logger.error('Error calling AI service for examples:', error);


### PR DESCRIPTION
### Motivation
- Unify the backend AI client with the FastAPI-based AI service to standardize endpoints and request/response shapes for chat, analysis, embeddings, and similarity checks.
- Ensure the backend can authenticate to the AI service via a single header and support agent vs assistant workflows consistently.
- Provide a clear API contract for other developers and CI to integrate against the running AI service.

### Description
- Updated `src/backend/src/utils/aiService.ts` to add `getApiHeaders()` and `postChat()` and to rework `askQuestion`, `generateScript`, `analyzeScript`, `explainScript`, and `getSimilarExamples` to call the FastAPI endpoints (`/chat`, `/analyze`, `/similar`) and map options to query params like `include_command_details` and `fetch_ms_docs`.
- Added support for sending a service-level API key via the `AI_SERVICE_API_KEY` env var as the `x-api-key` header in requests.
- Added the API contract document `docs/AI_SERVICE_API_CONTRACT.md` describing endpoints, request bodies, query parameters, and expected responses for the FastAPI service.
- Added a smoke test script `scripts/test-ai-service-contract.sh` that exercises `/health`, `/chat`, and `/analyze` using `curl` and `jq` to validate the running AI service.

### Testing
- No automated integration tests were executed in this environment because the AI service was not running. 
- The smoke test `scripts/test-ai-service-contract.sh` was added to validate endpoints and header usage when an AI service instance is available. 
- Static change verification: updated `aiService.ts` compiles in normal TypeScript build flows (no runtime AI calls performed here). 
- Manual lint/tests were not run as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961474608e0832ea6c6e296e569aa94)