### PR TITLE
Persist regenerated embeddings and extend AI batch endpoint

### DIFF
--- a/src/ai/main_real.py
+++ b/src/ai/main_real.py
@@ -92,6 +92,12 @@ class SimilaritySearchResponse(BaseModel):
     source_script: Dict[str, Any]
     similar_scripts: List[Dict[str, Any]]
     search_time_ms: float
+
+class EmbeddingBatchRequest(BaseModel):
+    scripts: List[Dict[str, Any]] = Field(default_factory=list)
+    persist: bool = Field(True, description="Persist embeddings to the database")
+    model: Optional[str] = Field(None, description="Embedding model to use")
+    dimensions: Optional[int] = Field(None, description="Embedding dimensions")
 class ScriptAnalysisRequest(BaseModel):
     script_content: str = Field(..., description="PowerShell script content")
     script_id: Optional[int] = Field(None, description="Optional script ID from the database")
@@ -352,9 +358,19 @@ async def generate_embedding(request: EmbeddingRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/generate-embeddings")
-async def generate_embeddings(scripts: List[Dict[str, Any]]):
+async def generate_embeddings(payload: Any):
     """Generate embeddings for multiple scripts"""
     try:
+        if isinstance(payload, list):
+            request = EmbeddingBatchRequest(scripts=payload)
+        elif isinstance(payload, dict):
+            request = EmbeddingBatchRequest(**payload)
+        else:
+            raise HTTPException(status_code=400, detail="Invalid payload for embeddings")
+
+        scripts = request.scripts
+        embedding_model = request.model or "text-embedding-3-large"
+        embedding_dimensions = request.dimensions or 3072
         results = []
         
         for script in scripts:
@@ -363,45 +379,53 @@ async def generate_embeddings(scripts: List[Dict[str, Any]]):
             
             # Generate embedding
             response = client.embeddings.create(
-                model="text-embedding-3-large",
+                model=embedding_model,
                 input=text,
-                dimensions=3072  # text-embedding-3-large has 3072 dimensions by default
+                dimensions=embedding_dimensions
             )
             
             embedding = response.data[0].embedding
+            persisted = False
             
-            # Store in database
-            conn = get_db_connection()
-            cur = conn.cursor()
+            if request.persist:
+                # Store in database
+                conn = get_db_connection()
+                cur = conn.cursor()
+                
+                try:
+                    cur.execute("""
+                        INSERT INTO script_embeddings (script_id, embedding, embedding_model, embedding_dimensions, created_at)
+                        VALUES (%s, %s, %s, %s, NOW())
+                        ON CONFLICT (script_id) 
+                        DO UPDATE SET 
+                            embedding = EXCLUDED.embedding, 
+                            embedding_model = EXCLUDED.embedding_model,
+                            embedding_dimensions = EXCLUDED.embedding_dimensions,
+                            updated_at = NOW()
+                    """, (script['id'], embedding, embedding_model, embedding_dimensions))
+                    
+                    conn.commit()
+                    persisted = True
+                except Exception as e:
+                    conn.rollback()
+                    results.append({
+                        "script_id": script.get('id'),
+                        "success": False,
+                        "error": str(e)
+                    })
+                    continue
+                finally:
+                    cur.close()
+                    conn.close()
             
-            try:
-                cur.execute("""
-                    INSERT INTO script_embeddings (script_id, embedding, embedding_model, embedding_dimensions, created_at)
-                    VALUES (%s, %s, %s, %s, NOW())
-                    ON CONFLICT (script_id) 
-                    DO UPDATE SET 
-                        embedding = EXCLUDED.embedding, 
-                        embedding_model = EXCLUDED.embedding_model,
-                        embedding_dimensions = EXCLUDED.embedding_dimensions,
-                        updated_at = NOW()
-                """, (script['id'], embedding, 'text-embedding-3-large', 3072))
-                
-                conn.commit()
-                
-                results.append({
-                    "script_id": script['id'],
-                    "success": True
-                })
-            except Exception as e:
-                conn.rollback()
-                results.append({
-                    "script_id": script['id'],
-                    "success": False,
-                    "error": str(e)
-                })
-            finally:
-                cur.close()
-                conn.close()
+            results.append({
+                "script_id": script.get('id'),
+                "success": True,
+                "embedding": embedding,
+                "model": embedding_model,
+                "dimensions": embedding_dimensions,
+                "persisted": persisted
+            })
         
         return {
             "total": len(scripts),

--- a/src/backend/src/routes/ai-advanced.ts
+++ b/src/backend/src/routes/ai-advanced.ts
@@ -4,6 +4,8 @@
  */
 import express from 'express';
 import axios from 'axios';
+import { QueryTypes } from 'sequelize';
+import { sequelize } from '../database/connection';
 import { corsMiddleware } from '../middleware/corsMiddleware';
 import logger from '../utils/logger';
 
@@ -14,6 +16,10 @@ router.use(corsMiddleware);
 
 // AI service configuration
 const AI_SERVICE_URL = process.env.AI_SERVICE_URL || 'http://ai:8000';
+const DEFAULT_EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || 'text-embedding-3-large';
+const DEFAULT_EMBEDDING_DIMENSIONS = Number(process.env.EMBEDDING_DIMENSIONS) || 3072;
+
+const formatVectorLiteral = (embedding: number[]): string => `[${embedding.join(',')}]`;
 
 /**
  * @swagger
@@ -248,25 +254,202 @@ router.get('/embeddings/status', async (req, res) => {
 router.post('/regenerate-embeddings', async (req, res) => {
   try {
     const { script_ids, batch_size = 10 } = req.body;
+    const scriptIds = Array.isArray(script_ids) ? script_ids : undefined;
+    const batchSize = Math.max(1, Number(batch_size) || 10);
+    const embeddingModel = DEFAULT_EMBEDDING_MODEL;
+    const embeddingDimensions = DEFAULT_EMBEDDING_DIMENSIONS;
     
-    logger.info('Regenerate embeddings request', { script_ids, batch_size });
+    logger.info('Regenerate embeddings request', { script_ids: scriptIds, batch_size: batchSize });
+
+    if (scriptIds && scriptIds.length === 0) {
+      res.json({
+        message: 'No script IDs provided for embedding regeneration',
+        batch_size: batchSize,
+        total_scripts: 0
+      });
+      return;
+    }
     
     // Get scripts that need regeneration
-    const scriptsQuery = script_ids 
-      ? `SELECT * FROM scripts WHERE id = ANY($1::int[])` 
-      : `SELECT s.* FROM scripts s 
+    const scriptsQuery = scriptIds
+      ? `SELECT s.id, s.title, s.description, s.content
+         FROM scripts s
+         WHERE s.id = ANY(:scriptIds::int[])`
+      : `SELECT s.id, s.title, s.description, s.content
+         FROM scripts s
          LEFT JOIN script_embeddings se ON s.id = se.script_id
-         WHERE se.embedding IS NULL 
-            OR se.embedding_model != 'text-embedding-3-large'
-            OR se.embedding_dimensions != 3072
-         LIMIT $1`;
-    
-    // This would be implemented in the actual controller
-    // For now, we'll return a placeholder response
+         WHERE se.embedding IS NULL
+            OR se.embedding_model IS NULL
+            OR se.embedding_model != :embeddingModel
+            OR se.embedding_dimensions IS NULL
+            OR se.embedding_dimensions != :embeddingDimensions
+            OR se.updated_at IS NULL
+            OR s.updated_at > se.updated_at`;
+
+    const scripts = await sequelize.query<{
+      id: number;
+      title: string;
+      description: string | null;
+      content: string;
+    }>(scriptsQuery, {
+      type: QueryTypes.SELECT,
+      replacements: scriptIds
+        ? { scriptIds }
+        : {
+            embeddingModel,
+            embeddingDimensions
+          }
+    });
+
+    if (scripts.length === 0) {
+      logger.info('No scripts require embedding regeneration');
+      res.json({
+        message: 'No scripts require embedding regeneration',
+        batch_size: batchSize,
+        total_scripts: 0
+      });
+      return;
+    }
+
+    logger.info('Scripts queued for embedding regeneration', {
+      totalScripts: scripts.length,
+      batchSize
+    });
+
+    const failedBatches: Array<{ batch: number; error: string; script_ids: number[] }> = [];
+    const failedScripts: Array<{ script_id: number; error: string; batch: number }> = [];
+    let processedScripts = 0;
+
+    for (let i = 0; i < scripts.length; i += batchSize) {
+      const batch = scripts.slice(i, i + batchSize);
+      const batchNumber = Math.floor(i / batchSize) + 1;
+      const scriptIds = batch.map((script) => script.id);
+
+      logger.info('Processing embedding batch', {
+        batch: batchNumber,
+        batchSize: batch.length,
+        totalScripts: scripts.length
+      });
+
+      try {
+        const response = await axios.post(`${AI_SERVICE_URL}/generate-embeddings`, {
+          scripts: batch.map((script) => ({
+            id: script.id,
+            name: script.title,
+            title: script.title,
+            description: script.description,
+            content: script.content
+          })),
+          persist: false,
+          model: embeddingModel,
+          dimensions: embeddingDimensions
+        });
+
+        const batchResults = response.data?.results;
+        const batchFailures: Array<{ script_id: number; error: string; batch: number }> = [];
+        let persistedCount = 0;
+        if (Array.isArray(batchResults)) {
+          for (const result of batchResults as Array<{
+            script_id: number;
+            success: boolean;
+            error?: string;
+            embedding?: number[];
+            model?: string;
+            dimensions?: number;
+          }>) {
+            if (!result.success) {
+              batchFailures.push({
+                script_id: result.script_id,
+                error: result.error || 'Unknown error',
+                batch: batchNumber
+              });
+              continue;
+            }
+
+            if (!Array.isArray(result.embedding)) {
+              batchFailures.push({
+                script_id: result.script_id,
+                error: 'Missing embedding payload',
+                batch: batchNumber
+              });
+              continue;
+            }
+
+            try {
+              await sequelize.query(
+                `INSERT INTO script_embeddings (
+                  script_id,
+                  embedding,
+                  embedding_model,
+                  embedding_dimensions,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :scriptId,
+                  :embedding::vector,
+                  :embeddingModel,
+                  :embeddingDimensions,
+                  NOW(),
+                  NOW()
+                )
+                ON CONFLICT (script_id)
+                DO UPDATE SET
+                  embedding = EXCLUDED.embedding,
+                  embedding_model = EXCLUDED.embedding_model,
+                  embedding_dimensions = EXCLUDED.embedding_dimensions,
+                  updated_at = NOW()`,
+                {
+                  replacements: {
+                    scriptId: result.script_id,
+                    embedding: formatVectorLiteral(result.embedding),
+                    embeddingModel: result.model || embeddingModel,
+                    embeddingDimensions: result.dimensions || embeddingDimensions
+                  },
+                  type: QueryTypes.INSERT
+                }
+              );
+              persistedCount += 1;
+            } catch (persistError: any) {
+              batchFailures.push({
+                script_id: result.script_id,
+                error: persistError.message || 'Failed to persist embedding',
+                batch: batchNumber
+              });
+            }
+          }
+        }
+        failedScripts.push(...batchFailures);
+
+        const successfulCount = response.data?.successful ?? (batch.length - batchFailures.length);
+        logger.info('Completed embedding batch', {
+          batch: batchNumber,
+          successful: successfulCount,
+          failed: batch.length - successfulCount,
+          persisted: persistedCount
+        });
+      } catch (error: any) {
+        const errorMessage = error.response?.data?.detail || error.message || 'Unknown error';
+        logger.error('Embedding batch failed', {
+          batch: batchNumber,
+          error: errorMessage
+        });
+        failedBatches.push({ batch: batchNumber, error: errorMessage, script_ids: scriptIds });
+      }
+
+      processedScripts += batch.length;
+      logger.info('Embedding regeneration progress', {
+        processedScripts,
+        totalScripts: scripts.length
+      });
+    }
+
     res.json({
-      message: 'Embedding regeneration started',
-      batch_size,
-      script_ids: script_ids || 'all scripts needing update'
+      message: 'Embedding regeneration completed',
+      batch_size: batchSize,
+      total_scripts: scripts.length,
+      failed_batches: failedBatches,
+      failed_scripts: failedScripts
     });
     
   } catch (error: any) {


### PR DESCRIPTION
### Motivation
- Ensure regenerated embeddings are persisted in the backend with model and dimension metadata so similarity and semantic features remain consistent.
- Avoid timeouts and improve throughput by sending scripts to the AI service in batches for embedding generation.
- Surface batch and per-script failures so operators can retry or investigate problematic items.

### Description
- Added `DEFAULT_EMBEDDING_MODEL`, `DEFAULT_EMBEDDING_DIMENSIONS` and `formatVectorLiteral` and updated the `/api/ai/advanced/regenerate-embeddings` flow in `src/backend/src/routes/ai-advanced.ts` to select scripts that need regeneration and process them in batches. 
- Changed the backend to POST batches to the AI service with `persist: false` and embedding options (`model`, `dimensions`), then upsert returned embeddings into `script_embeddings` using `sequelize.query` and a `:embedding::vector` replacement while tracking `persisted` counts. 
- Aggregated failures into `failed_batches` and `failed_scripts` and added progress logging for each batch. 
- Extended the AI service in `src/ai/main_real.py` by adding an `EmbeddingBatchRequest` model and updating the `/generate-embeddings` endpoint to accept a payload with `scripts`, optional `persist`, `model`, and `dimensions`, and to return per-script `embedding`, `model`, `dimensions`, and `persisted` info when applicable.

### Testing
- No automated tests were executed against the modified code as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614754b3ec832e868118b7a55ec4ba)